### PR TITLE
Added option for Revenant to respawn at a world spawnpoint instead of their corpse

### DIFF
--- a/lua/terrortown/autorun/shared/sh_reven_convars.lua
+++ b/lua/terrortown/autorun/shared/sh_reven_convars.lua
@@ -2,7 +2,7 @@ CreateConVar("ttt2_reven_revival_time", 15, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_
 CreateConVar("ttt2_reven_damage_bonus", 0.5, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 CreateConVar("ttt2_reven_worldspawn", 0, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 
-hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_wrath_convars", function(tbl)
+hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_revenant_convars", function(tbl)
 	tbl[ROLE_REVENANT] = tbl[ROLE_REVENANT] or {}
 
 	table.insert(tbl[ROLE_REVENANT], {
@@ -21,5 +21,11 @@ hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_wrath_convars", function(tbl)
 		max = 5,
 		decimal = 1,
 		desc = "ttt2_reven_damage_bonus (def. 0.5)"
+	})
+
+	table.insert(tbl[ROLE_REVENANT], {
+		cvar = "ttt2_reven_worldspawn",
+		checkbox = true,
+		desc = "ttt2_reven_worldspawn (def. 0)"
 	})
 end)

--- a/lua/terrortown/autorun/shared/sh_reven_convars.lua
+++ b/lua/terrortown/autorun/shared/sh_reven_convars.lua
@@ -1,5 +1,6 @@
 CreateConVar("ttt2_reven_revival_time", 15, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 CreateConVar("ttt2_reven_damage_bonus", 0.5, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
+CreateConVar("ttt2_reven_worldspawn", 0, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 
 hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_wrath_convars", function(tbl)
 	tbl[ROLE_REVENANT] = tbl[ROLE_REVENANT] or {}

--- a/lua/terrortown/entities/roles/revenant/shared.lua
+++ b/lua/terrortown/entities/roles/revenant/shared.lua
@@ -51,6 +51,7 @@ if SERVER then
 	function ROLE:GiveRoleLoadout(ply, isRoleChange)
 		if ply.revenant_state == nil or ply.revenant_state == 0 then
 			ply.revenant_state = 1
+			ply.isRevenantWorldspawn = false
 		end
 	end
 
@@ -58,18 +59,27 @@ if SERVER then
 		if ply:GetSubRole() ~= ROLE_REVENANT or ply.revenant_state == 2 then return end
 		if SpecDM and (ply.IsGhost and ply:IsGhost() or (attacker.IsGhost and attacker:IsGhost())) then return end
 
+		local spawnpoint = plyspawn.GetRandomSafePlayerSpawnPoint(ply)
+
 		ply:Revive(GetConVar("ttt2_reven_revival_time"):GetInt(),
 			function(p)
 				ply.revenant_state = 2
 				ply:UpdateTeam(TEAM_REVENANT)
-				p:ResetConfirmPlayer()
+				ply:ResetConfirmPlayer()
 				SendFullStateUpdate()
+				if ply.isRevenantWorldspawn or GetConVar('ttt2_reven_worldspawn'):GetBool() then
+					ply:SetPos(spawnpoint)
+				end
 			end,
 			nil,
 			false,
 			REVIVAL_BLOCK_ALL
 		)
-		ply:SendRevivalReason("ttt2_role_reven_revival_message")
+		if not GetConVar('ttt2_reven_worldspawn'):GetBool() then
+			ply:SendRevivalReason("ttt2_role_reven_revival_message_spawn_option")
+		else
+			ply:SendRevivalReason("ttt2_role_reven_revival_message")
+		end
 	end)
 
 	hook.Add("TTT2SpecialRoleSyncing", "TTT2RoleRevenMod", function(ply, tbl)
@@ -119,6 +129,17 @@ if SERVER then
 	
 	  hook.Add("TTTEndRound", "DuelistEndRound", ResetRevenants)
 	  hook.Add("TTTPrepareRound", "DuelistPrepareRound", ResetRevenants)
+
+	  hook.Add("KeyPress", "TTT2RevenantDoWorldSpawn", function (ply, key)
+		if ply:GetSubRole() ~= ROLE_REVENANT then return end
+		if not ply.isReviving then return end
+		if key ~= IN_RELOAD then return end
+		if ply.isRevenantWorldspawn or GetConVar("ttt2_reven_worldspawn"):GetBool() then return end
+
+		ply.isRevenantWorldspawn = true
+		ply:SendRevivalReason("ttt2_role_reven_revival_message")
+
+	  end)
 	
 end
 
@@ -140,6 +161,11 @@ if CLIENT then
 			min = 0,
 			max = 5,
 			decimal = 1
+		})
+
+		form:MakeCheckbox({
+			serverConvar = "ttt2_reven_worldspawn",
+			label = "label_reven_worldspawn",
 		})
 	end
 end

--- a/lua/terrortown/entities/roles/revenant/shared.lua
+++ b/lua/terrortown/entities/roles/revenant/shared.lua
@@ -164,7 +164,7 @@ if CLIENT then
 			decimal = 1
 		})
 
-		form:MakeCheckbox({
+		form:MakeCheckBox({
 			serverConvar = "ttt2_reven_worldspawn",
 			label = "label_reven_worldspawn",
 		})

--- a/lua/terrortown/entities/roles/revenant/shared.lua
+++ b/lua/terrortown/entities/roles/revenant/shared.lua
@@ -68,7 +68,7 @@ if SERVER then
 				ply:ResetConfirmPlayer()
 				SendFullStateUpdate()
 				if ply.isRevenantWorldspawn or GetConVar('ttt2_reven_worldspawn'):GetBool() then
-					ply:SetPos(spawnpoint)
+					ply:SetPos(spawnpoint.pos)
 				end
 			end,
 			nil,

--- a/lua/terrortown/entities/roles/revenant/shared.lua
+++ b/lua/terrortown/entities/roles/revenant/shared.lua
@@ -69,6 +69,7 @@ if SERVER then
 				SendFullStateUpdate()
 				if ply.isRevenantWorldspawn or GetConVar('ttt2_reven_worldspawn'):GetBool() then
 					ply:SetPos(spawnpoint.pos)
+					ply:SetAngles(spawnpoint.ang)
 				end
 			end,
 			nil,

--- a/lua/terrortown/lang/en/revenant.lua
+++ b/lua/terrortown/lang/en/revenant.lua
@@ -15,6 +15,8 @@ L["ttt2_desc_" .. REVENANT.name] = [[The Revenant is an innocent role and works 
 -- OTHER ROLE LANGUAGE STRINGS
 
 L["ttt2_role_reven_revival_message"] = "You will be revived as a Revenant!"
+L["ttt2_role_reven_revival_message_spawn_option"] = "You will be revived as a Revenant! Press Reload to respawn at a map spawnpoint."
 
 L["label_reven_revival_time"] = "How long it takes to revive"
 L["label_reven_damage_bonus"] = "Damage bonus"
+L["label_reven_worldspawn"] = "Always spawn at worldspawn"


### PR DESCRIPTION
Added convar to make them always respawn at a spawnpoint or alternatively added option when respawning for Revenant to press Reload to change their spawn from their corpse to a world spawnpoint.